### PR TITLE
Fix V547 warning from PVS-Studio Static Analyzer

### DIFF
--- a/src/compressor.c
+++ b/src/compressor.c
@@ -86,8 +86,7 @@ void sf_advancecomp(sf_compressor_state_st *state, int rate, float pregain, floa
 		delaybufsize = 1;
 	else if (delaybufsize > SF_COMPRESSOR_MAXDELAY)
 		delaybufsize = SF_COMPRESSOR_MAXDELAY;
-	if (delaybufsize > 0)
-		memset(state->delaybuf, 0, sizeof(sf_sample_st) * delaybufsize);
+        memset(state->delaybuf, 0, sizeof(sf_sample_st) * delaybufsize);
 
 	// useful values
 	float linearpregain = db2lin(pregain);


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Warning:
Expression 'delaybufsize > 0' is always true.