### PR TITLE
Fix V519 warning from PVS-Studio Static Analyzer

### DIFF
--- a/src/compressor.c
+++ b/src/compressor.c
@@ -153,7 +153,6 @@ void sf_advancecomp(sf_compressor_state_st *state, int rate, float pregain, floa
 	state->slope                = slope;
 	state->attacksamplesinv     = attacksamplesinv;
 	state->satreleasesamplesinv = satreleasesamplesinv;
-	state->wet                  = wet;
 	state->dry                  = dry;
 	state->k                    = k;
 	state->kneedboffset         = kneedboffset;


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Warning:
The 'state->wet' variable is assigned values twice successively.